### PR TITLE
Bug Fix - for dockerhub API getting DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocDockerManager
 Type: Package
 Title: Access Bioconductor docker images
-Version: 1.9.0
+Version: 1.9.1
 Authors@R: c(
     person(
 	"Bioconductor Package Maintainer",

--- a/R/dockerhub_api.R
+++ b/R/dockerhub_api.R
@@ -188,12 +188,12 @@
 
     organization <- split_repo[1]
 
-    full_org <- .memoised_docker_get_organization(organization)
-
-    idx <- which(name == vapply(full_org, `[[`, character(1), "name"))
-
-    trimws(full_org[[idx]]$description)
+    trimws(.docker_get(repository)$description)
 }
+
+#' @importFrom memoise memoise
+.memoised_docker_image_description <- 
+    memoise::memoise(.docker_image_description)
 
 
 ## Get all the docker image digest values for the image name provided

--- a/R/manager.R
+++ b/R/manager.R
@@ -49,22 +49,31 @@ available <-
         images <- images[filter]
     }
     repositories <- .docker_repository_list(organization, images)
+    
     ## Get descriptions
-    image_descriptions <- vapply(
-        repositories, .docker_image_description, character(1)
-    )
+    ## image_descriptions <- vapply(
+    ##     repositories, .memoised_docker_image_description, character(1)
+    ## )
+    
     ## Filter deprecated images
-    if(!deprecated) {
-        include <- !grepl("DEPRECATED", image_descriptions)
-        image_descriptions <- image_descriptions[include]
+    if (!deprecated) {
+        
+        ## TODO: This is a hack, getting the description from the
+        ## dockerhub api was 'rate' limited, which was causing an
+        ## issue with the build system
+        include <- !grepl("^release|^devel|^mzr", images)
         repositories <- repositories[include]
         images <- images[include]
+        ## include <- !grepl("DEPRECATED", image_descriptions)
+        ## image_descriptions <- image_descriptions[include]
+        ## repositories <- repositories[include]
+        ## images <- images[include]
     }
     ## get tags in a list
     tags <- lapply(repositories, .docker_image_tags_list)
-    image_tags <- vapply(tags, paste, character(1), collapse=", ")
+    image_tags <- vapply(tags, paste, character(1), collapse = ", ")
     image_tags[!nzchar(image_tags)] <- NA_character_
-    image_descriptions[!nzchar(image_descriptions)] <- NA_character_
+    # image_descriptions[!nzchar(image_descriptions)] <- NA_character_
     ## Get pull count
     pull_count <- vapply(
         repositories, .docker_image_pull_count,numeric(1)
@@ -72,7 +81,7 @@ available <-
     ## result
     tibble(
         IMAGE = images,
-        DESCRIPTION = image_descriptions,
+        # DESCRIPTION = image_descriptions,
         TAGS = trimws(image_tags),
         REPOSITORY = repositories,
         DOWNLOADS = pull_count

--- a/vignettes/BiocDockerManager.Rmd
+++ b/vignettes/BiocDockerManager.Rmd
@@ -102,7 +102,7 @@ example below, simply finding the details related to the
 
 ```{r}
 res %>%
-    select(IMAGE, DESCRIPTION, TAGS) %>%
+    select(IMAGE, TAGS) %>%
     filter(IMAGE == "bioconductor_docker")
 ```
 
@@ -112,7 +112,7 @@ the help of the `pattern` argument.
 ```{r available2}
 res2 <- BiocDockerManager::available(pattern = "bioconductor_docker")
 
-res2 %>% select(IMAGE, DESCRIPTION, TAGS)
+res2 %>% select(IMAGE, TAGS)
 ```
 
 We can see that for the `bioconductor/bioconductor_docker` image the
@@ -123,7 +123,7 @@ deprecated. These images can be obtained in the following way.
 
 ```{r deprecated, eval = TRUE}
 BiocDockerManager::available(deprecated=TRUE) %>%
-    select(IMAGE, DESCRIPTION)
+    select(IMAGE)
 ```
 
 ## Help regarding Bioconductor images


### PR DESCRIPTION
- Update patch version (1.9.1)

- Issue: Dockerhub API is hitting the rate limit imposed on non-authenticated access to get the "Description" of the containers that are hosted on the dockerhub registry.

- The new dockerhub API doesn't help in fixing this issue, so, I've removed the functionality for showing the description of the container.

- The description is non-essential, as the information shown doesn't really inform the user of the functionality of the container.

- This can be fixed as Dockerhub API is improved later. 

NOTE: memoizing the function to extract "description" did not work. Still hits rate limit