### PR TITLE
Fix tests for the function BiocDockerManager::available()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocDockerManager
 Type: Package
 Title: Access Bioconductor docker images
-Version: 1.9.1
+Version: 1.9.2
 Authors@R: c(
     person(
 	"Bioconductor Package Maintainer",

--- a/tests/testthat/test-manager.R
+++ b/tests/testthat/test-manager.R
@@ -32,7 +32,7 @@ test_that("'available()' works as expected", {
                 organization = "bioconductor", 
                 deprecated = FALSE)
     expect_true("bioconductor_docker" %in% res1$IMAGE)
-    expect_length(res1, 5)
+    expect_length(res1, 4)
     expect_length(nrow(res1), 1)
 
     ## include deprecated


### PR DESCRIPTION
- The function expected 5 columns before, but since the "description" of
the docker containers was removed, it should only expect 4.

- The description was removed because of "rate limiting" from the
dockerhub API